### PR TITLE
Windows Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 
 VERSION=0.2dev
 
+ifeq ($(OS),Windows_NT)
+	ASSETS_DIR := .\assets
+else
+	ASSETS_DIR := ./assets
+endif
+
 all: assets build
 
 
@@ -17,14 +23,16 @@ release:
 
 assets: guest kernel v86
 
+guest: export GOOS=linux
+guest: export GOARCH=386
 guest:
-	cd ./cmd/guest86 && GOOS=linux GOARCH=386 go build -o ../../assets/guest86 .
+	cd ./cmd/guest86 && go build -o ../../assets/guest86 .
 
 kernel:
 	docker build --platform=linux/386 -t env86-kernel -f ./scripts/Dockerfile.kernel ./scripts
-	docker run --rm --platform=linux/386 -v ./assets:/dst env86-kernel
+	docker run --rm --platform=linux/386 -v $(ASSETS_DIR):/dst env86-kernel
 
 v86:
 	docker build -t env86-v86 -f ./scripts/Dockerfile.v86 ./scripts
-	docker run --rm -v ./assets:/dst env86-v86
+	docker run --rm -v $(ASSETS_DIR):/dst env86-v86
 

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,17 @@ VERSION=0.2dev
 
 ifeq ($(OS),Windows_NT)
 	ASSETS_DIR := .\assets
+	ENV86 := .\env86.exe
 else
 	ASSETS_DIR := ./assets
+	ENV86 := ./env86
 endif
 
 all: assets build
 
 
 build:
-	go build -ldflags="-X 'main.Version=${VERSION}'" -o ./env86 ./cmd/env86
+	go build -ldflags="-X 'main.Version=${VERSION}'" -o $(ENV86) ./cmd/env86
 
 install: build
 	mv ./env86 /usr/local/bin/env86

--- a/cmd/env86/boot.go
+++ b/cmd/env86/boot.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/progrium/env86"
@@ -34,12 +35,18 @@ func bootCmd() *cli.Command {
 		Args:  cli.MinArgs(1),
 		Run: func(ctx *cli.Context, args []string) {
 			imagePath := args[0]
-			if !strings.HasPrefix(imagePath, "./") {
+			var err error
+			if !strings.HasPrefix(imagePath, "./") && !strings.HasPrefix(imagePath, ".\\") {
 				exists, fullPath := globalImage(imagePath)
 				if !exists {
 					log.Fatal("global image not found")
 				}
 				imagePath = fullPath
+			} else {
+				imagePath, err = filepath.Abs(imagePath)
+				if err != nil {
+					log.Fatal(err)
+				}
 			}
 
 			image, err := env86.LoadImage(imagePath)

--- a/cmd/env86/create.go
+++ b/cmd/env86/create.go
@@ -31,7 +31,7 @@ func createCmd() *cli.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			exists, err := fs.Exists(os.DirFS("/"), strings.TrimPrefix(imagePath, "/"))
+			exists, err := fs.Exists(fsutil.RootFS(imagePath), fsutil.RootFSRelativePath(imagePath))
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/env86/create.go
+++ b/cmd/env86/create.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/progrium/env86/assets"
 	"github.com/progrium/env86/fsutil"
@@ -44,7 +43,7 @@ func createCmd() *cli.Command {
 				if err != nil {
 					log.Fatal(err)
 				}
-				isDir, err := fs.IsDir(os.DirFS("/"), strings.TrimPrefix(dir, "/"))
+				isDir, err := fs.IsDir(fsutil.RootFS(dir), fsutil.RootFSRelativePath(dir))
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -62,7 +61,7 @@ func createCmd() *cli.Command {
 				if err != nil {
 					log.Fatal(err)
 				}
-				isDockerfile, err := fs.Exists(os.DirFS("/"), strings.TrimPrefix(docker, "/"))
+				isDockerfile, err := fs.Exists(fsutil.RootFS(docker), fsutil.RootFSRelativePath(docker))
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/cmd/env86/main.go
+++ b/cmd/env86/main.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/progrium/env86/fsutil"
+
 	"tractor.dev/toolkit-go/desktop"
 	"tractor.dev/toolkit-go/engine/cli"
 	"tractor.dev/toolkit-go/engine/fs"
@@ -64,7 +66,7 @@ func globalImage(pathspec string) (bool, string) {
 	if err == nil {
 		path = resolved
 	}
-	ok, err := fs.Exists(os.DirFS("/"), strings.TrimLeft(path, "/"))
+	ok, err := fs.Exists(fsutil.RootFS(path), fsutil.RootFSRelativePath(path))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -78,7 +80,7 @@ func globalImage(pathspec string) (bool, string) {
 	}
 	// if no tag specified and latest not found, try local
 	path = filepath.Join(env86Path(), image, "local")
-	ok, err = fs.Exists(os.DirFS("/"), strings.TrimLeft(path, "/"))
+	ok, err = fs.Exists(fsutil.RootFS(path), fsutil.RootFSRelativePath(path))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/env86/main.go
+++ b/cmd/env86/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/progrium/env86/fsutil"
@@ -46,10 +47,14 @@ func main() {
 func env86Path() string {
 	path := os.Getenv("ENV86_PATH")
 	if path == "" {
-		path = "~/.env86"
+		if runtime.GOOS == "windows" {
+			path = filepath.Join(os.Getenv("APPDATA"), "env86")
+		} else {
+			usr, _ := user.Current()
+			path = usr.HomeDir + "/.env86"
+		}
 	}
-	usr, _ := user.Current()
-	return strings.ReplaceAll(path, "~", usr.HomeDir)
+	return path
 }
 
 // github.com/progrium/alpine@latest => ~/.env86/github.com/progrium/alpine/3.18

--- a/cmd/env86/main.go
+++ b/cmd/env86/main.go
@@ -57,7 +57,11 @@ func env86Path() string {
 	return path
 }
 
+// globalImage resolves a pathspec to a global image path
+// On Unix-like systems:
 // github.com/progrium/alpine@latest => ~/.env86/github.com/progrium/alpine/3.18
+// On Windows:
+// github.com/progrium/alpine@latest => %APPDATA%\env86\github.com\progrium\alpine\3.18
 func globalImage(pathspec string) (bool, string) {
 	parts := strings.Split(pathspec, "@")
 	image := strings.TrimSuffix(parts[0], "-env86")

--- a/cmd/env86/prepare.go
+++ b/cmd/env86/prepare.go
@@ -39,7 +39,7 @@ func prepareCmd() *cli.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			exists, err := fs.DirExists(os.DirFS("/"), strings.TrimLeft(dstPath, "/"))
+			exists, err := fs.DirExists(fsutil.RootFS(dstPath), fsutil.RootFSRelativePath(dstPath))
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -53,6 +53,7 @@ func prepareCmd() *cli.Command {
 				log.Fatal(err)
 			}
 
+			// osfs currently works with os native paths
 			dst := osfs.Dir(dstPath)
 			dst.MkdirAll("image", 0755)
 			if err := fsutil.CopyFS(preparedImage, ".", dst, "image"); err != nil {

--- a/cmd/env86/prepare.go
+++ b/cmd/env86/prepare.go
@@ -22,12 +22,18 @@ func prepareCmd() *cli.Command {
 		Args:  cli.MinArgs(2),
 		Run: func(ctx *cli.Context, args []string) {
 			imagePath := args[0]
-			if !strings.HasPrefix(imagePath, "./") {
+			var err error
+			if !strings.HasPrefix(imagePath, "./") && !strings.HasPrefix(imagePath, ".\\") {
 				exists, fullPath := globalImage(imagePath)
 				if !exists {
 					log.Fatal("global image not found")
 				}
 				imagePath = fullPath
+			} else {
+				imagePath, err = filepath.Abs(imagePath)
+				if err != nil {
+					log.Fatal(err)
+				}
 			}
 
 			image, err := env86.LoadImage(imagePath)

--- a/cmd/env86/pull.go
+++ b/cmd/env86/pull.go
@@ -159,12 +159,17 @@ func pullCmd() *cli.Command {
 				return
 			}
 			newImage := args[1]
-			if !strings.HasPrefix(newImage, "./") {
+			if !strings.HasPrefix(newImage, "./") && !strings.HasPrefix(newImage, ".\\") {
 				exists, fullPath := globalImage(newImage)
 				if exists {
 					log.Fatal("global image already exists")
 				}
 				newImage = fullPath
+			} else {
+				newImage, err = filepath.Abs(newImage)
+				if err != nil {
+					log.Fatal(err)
+				}
 			}
 			os.MkdirAll(filepath.Dir(newImage), 0755)
 			if err := fsutil.CopyFS(osfs.New(), imageDst, osfs.New(), newImage); err != nil {

--- a/fsutil/copy.go
+++ b/fsutil/copy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 
 	"tractor.dev/toolkit-go/engine/fs"
 )
@@ -100,7 +100,7 @@ func copyDir(srcFS fs.FS, srcPath string, dstFS fs.MutableFS, dstPath string, mo
 		return fmt.Errorf("error reading directory %q: %v", srcPath, err)
 	}
 	for _, entry := range entries {
-		if err := CopyFS(srcFS, filepath.Join(srcPath, entry.Name()), dstFS, filepath.Join(dstPath, entry.Name())); err != nil {
+		if err := CopyFS(srcFS, path.Join(srcPath, entry.Name()), dstFS, path.Join(dstPath, entry.Name())); err != nil {
 			return err
 		}
 	}

--- a/fsutil/path.go
+++ b/fsutil/path.go
@@ -1,0 +1,36 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"tractor.dev/toolkit-go/engine/fs"
+)
+
+func RootFSDir(path string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.VolumeName(path)
+	}
+	return "/"
+}
+
+func RootFS(path string) fs.FS {
+	return os.DirFS(RootFSDir(path))
+}
+
+/**
+* RootFSRelativePath returns the path relative to the root of the filesystem.
+* This is useful for checking if a file exists in a filesystem.
+* On Unix:
+* 	RootFSRelativePath("/foo/bar") => "foo/bar"
+* On Windows:
+* 	RootFSRelativePath("C:/foo/bar") => "foo/bar"
+*/
+func RootFSRelativePath(path string) string {
+	if runtime.GOOS == "windows" {
+		path = filepath.ToSlash(strings.TrimPrefix(path, filepath.VolumeName(path)))
+	}
+	return strings.TrimPrefix(path, "/")
+}

--- a/image.go
+++ b/image.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/progrium/env86/assets"
@@ -219,7 +220,7 @@ func splitFile(fsys fs.FS, filename string, outputDir string, bytesPerFile int) 
 	}
 	defer file.Close()
 
-	baseName := filepath.Base(filename)
+	baseName := path.Base(filename)
 
 	buffer := make([]byte, bytesPerFile)
 	part := 0
@@ -230,7 +231,7 @@ func splitFile(fsys fs.FS, filename string, outputDir string, bytesPerFile int) 
 		}
 
 		outputFilename := fmt.Sprintf("%s.%d", baseName, part)
-		outputFile, err := f.Create(filepath.Join(outputDir, outputFilename))
+		outputFile, err := f.Create(path.Join(outputDir, outputFilename))
 		if err != nil {
 			return 0, err
 		}
@@ -247,7 +248,7 @@ func splitFile(fsys fs.FS, filename string, outputDir string, bytesPerFile int) 
 			return 0, err
 		}
 		outputFile.Close()
-		if err := f.Chmod(filepath.Join(outputDir, outputFilename), 0644); err != nil {
+		if err := f.Chmod(path.Join(outputDir, outputFilename), 0644); err != nil {
 			return 0, err
 		}
 

--- a/image.go
+++ b/image.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/progrium/env86/assets"
 	"github.com/progrium/env86/fsutil"
@@ -41,7 +40,7 @@ func LoadImage(path string) (*Image, error) {
 		return nil, err
 	}
 
-	isDir, err := fs.IsDir(os.DirFS("/"), strings.TrimPrefix(imagePath, "/"))
+	isDir, err := fs.IsDir(fsutil.RootFS(imagePath), fsutil.RootFSRelativePath(imagePath))
 	if err != nil {
 		return nil, err
 	}

--- a/namespacefs/fs.go
+++ b/namespacefs/fs.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -85,12 +86,13 @@ func (host *FS) isPathInMount(path string) (bool, *binding) {
 }
 
 func cleanPath(p string) string {
-	return filepath.Clean(strings.TrimLeft(p, "/\\"))
+	return path.Clean(strings.TrimLeft(p, "/\\"))
 }
 
 func trimMountPoint(path string, mntPoint string) string {
 	result := strings.TrimPrefix(path, mntPoint)
-	result = strings.TrimPrefix(result, string(filepath.Separator))
+	// Separator is always / for io/fs instances
+	result = strings.TrimPrefix(result, string("/"))
 
 	if result == "" {
 		return "."


### PR DESCRIPTION
This will solve the Windows port issues:

- [x] Using `io/fs` relative paths, gradually updating the `filepath` calls
- [x] Handling user input paths on Windows, i.e `env86 boot E:\MyVMs\alpine`
- [x] Updating home directory
- [x] Fixing `Makefile` problems
   - [x] `GOOS` and `GOARCH` env variables
   - [x] Problem with assets directory for docker, has to be passed as `.\assets:/dst`